### PR TITLE
updating node version to the latest LTS version 10.15.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ USER circleci
 # Setup NVM Install Environment
 # ...
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 8.11.1
+ENV NODE_VERSION 10.15.0
 
 USER root
 


### PR DESCRIPTION
npm's audit command replaces the deprecated nsp command. Since audit was introduced in npm version 6 and is packaged with node version 10, the node version has been updated to the current LTS version.